### PR TITLE
Add bigint type support

### DIFF
--- a/docs/Column.md
+++ b/docs/Column.md
@@ -320,6 +320,24 @@ $schema = new Schema('table', function(Schema $schema): void{
 
 ***
 
+## unsigned_big( ?int $length = null ): Column
+
+> @param int|null $length Sets the max length of the columns value, passing null omits setting length.  
+> @return Column  
+
+Defines a `UNSIGNED INT(length)` with an optional length
+
+```php
+$schema = new Schema('table', function(Schema $schema): void{
+    // Using helper
+    $schema->column('some_string')->unsigned_big(16);
+    // Verbose
+    $schema->column('some_string')->type('unsigned_big')->length(16);
+});
+```
+
+***
+
 ## datetime( ?string $default = null ): Column
 
 > @param string|null $default  

--- a/src/Column_Types.php
+++ b/src/Column_Types.php
@@ -175,6 +175,21 @@ trait Column_Types {
 	}
 
 	/**
+	 * Sets column as an unsigned bigint with a defined length.
+	 * 
+	 * @param int|null $length
+	 * @return Column
+	 */
+	public function unsigned_big( ?int $length = null ): Column {
+		$this->type( 'bigint' );
+		$this->unsigned();
+		if ( null !== $length ) {
+			$this->length( $length );
+		}
+		return $this;
+	}
+
+	/**
 	 * Sets column as JSON with an optional default.
 	 *
 	 * @since 1.1.0

--- a/tests/Intergration/Test_Docs_Examples.php
+++ b/tests/Intergration/Test_Docs_Examples.php
@@ -60,8 +60,9 @@ class Test_Docs_Examples extends WP_UnitTestCase {
 			'ex_numeric_cols',
 			function( $schema ) {
 				// Length
-				$schema->column( 'verbose_length' )->type( 'mediumint' )->length( 123 );
-				$schema->column( 'shortcut_length' )->int( 12 );
+				$schema->column( 'verbose_length' )->type( 'bigint' )->length( 123 );
+				$schema->column( 'shortcut_length' )->type( 'mediumint' )->length( 9 );
+				$schema->column( 'assumed_length' )->int( 12 );
 
 				// Length with Precision
 				$schema->column( 'verbose_precision' )->type( 'double' )

--- a/tests/Test_Column_Types.php
+++ b/tests/Test_Column_Types.php
@@ -18,7 +18,7 @@ use PinkCrab\Table_Builder\Column;
 
 class Test_Column_Types extends WP_UnitTestCase {
 
-	/** @testdox It should be possible to set common types such as INT and it legnth in a simple and short fashion */
+	/** @testdox It should be possible to set common types such as INT and it length in a simple and short fashion */
 	public function test_int_type(): void {
 		$column_no_length = new Column( 'no_length' );
 		$column_no_length->int();
@@ -33,7 +33,7 @@ class Test_Column_Types extends WP_UnitTestCase {
 		$this->assertEquals( 12, $column_with_length->get_length() );
 	}
 
-	/** @testdox It should be possible to set common types such as VARCHAR and it legnth in a simple and short fashion */
+	/** @testdox It should be possible to set common types such as VARCHAR and it length in a simple and short fashion */
 	public function test_varchar_type(): void {
 		$column_no_length = new Column( 'no_length' );
 		$column_no_length->varchar();
@@ -48,7 +48,7 @@ class Test_Column_Types extends WP_UnitTestCase {
 		$this->assertEquals( 12, $column_with_length->get_length() );
 	}
 
-	/** @testdox It should be possible to set common types such as TEXT and it legnth in a simple and short fashion */
+	/** @testdox It should be possible to set common types such as TEXT and it length in a simple and short fashion */
 	public function test_text_type(): void {
 		$column_no_length = new Column( 'no_length' );
 		$column_no_length->text();
@@ -63,7 +63,7 @@ class Test_Column_Types extends WP_UnitTestCase {
 		$this->assertEquals( 12, $column_with_length->get_length() );
 	}
 
-	/** @testdox It should be possible to set common types such as FLOAT and it legnth in a simple and short fashion */
+	/** @testdox It should be possible to set common types such as FLOAT and it length in a simple and short fashion */
 	public function test_float_type(): void {
 		$column_no_length = new Column( 'no_length' );
 		$column_no_length->float();
@@ -78,7 +78,7 @@ class Test_Column_Types extends WP_UnitTestCase {
 		$this->assertEquals( 12, $column_with_length->get_length() );
 	}
 
-	/** @testdox It should be possible to set common types such as DOUBLE and it legnth in a simple and short fashion */
+	/** @testdox It should be possible to set common types such as DOUBLE and it length in a simple and short fashion */
 	public function test_double_type(): void {
 		$column_no_length = new Column( 'no_length' );
 		$column_no_length->double();
@@ -102,7 +102,7 @@ class Test_Column_Types extends WP_UnitTestCase {
 		$this->assertEquals( 6, $column_with_precision->get_precision() );
 	}
 
-	/** @testdox It should be possible to set common types such as UNSIGNED INT and it legnth in a simple and short fashion */
+	/** @testdox It should be possible to set common types such as UNSIGNED INT and it length in a simple and short fashion */
 	public function test_unsigned_int_type(): void {
 		$column_no_length = new Column( 'no_length' );
 		$column_no_length->unsigned_int();
@@ -119,7 +119,7 @@ class Test_Column_Types extends WP_UnitTestCase {
 		$this->assertEquals( 12, $column_with_length->get_length() );
 	}
 
-	/** @testdox It should be possible to set common types such as UNSIGNED MEDIUM and it legnth in a simple and short fashion */
+	/** @testdox It should be possible to set common types such as UNSIGNED MEDIUM and it length in a simple and short fashion */
 	public function test_unsigned_medium_type(): void {
 		$column_no_length = new Column( 'no_length' );
 		$column_no_length->unsigned_medium();
@@ -132,6 +132,23 @@ class Test_Column_Types extends WP_UnitTestCase {
 		$column_with_length->unsigned_medium( 12 );
 
 		$this->assertEquals( 'mediumint', $column_with_length->get_type() );
+		$this->assertTrue( $column_no_length->is_unsigned() );
+		$this->assertEquals( 12, $column_with_length->get_length() );
+	}
+
+	/** @testdox It should be possible to set common types such as UNSIGNED BIG and it length in a simple and short fashion */
+	public function test_unsigned_big_type(): void {
+		$column_no_length = new Column( 'no_length' );
+		$column_no_length->unsigned_big();
+
+		$this->assertEquals( 'bigint', $column_no_length->get_type() );
+		$this->assertEquals( null, $column_no_length->get_length() );
+		$this->assertTrue( $column_no_length->is_unsigned() );
+
+		$column_with_length = new Column( 'with_length' );
+		$column_with_length->unsigned_big( 12 );
+
+		$this->assertEquals( 'bigint', $column_with_length->get_type() );
 		$this->assertTrue( $column_no_length->is_unsigned() );
 		$this->assertEquals( 12, $column_with_length->get_length() );
 	}


### PR DESCRIPTION
It would be nice if we support `BIGINT(20) unsigned` because WordPress uses them for their IDs column and will be useful for someone who wants to enforce real foreign keys relationship.